### PR TITLE
Update README.md direcionar para Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ Vá para a Wiki deste repositório, lá voce encontrará instruções de como su
 * Melhoria na qualidade do código do front-end (fizemos na pressa devido a urgência)
 
 ## Contate os fundadores
-g
 * Renoir dos Reis (@renoirfaria)
   renofaria@gmail.com
 * Igor Rincon (@igrrincon)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,19 @@
 # Projeto Hardpath
+Repositório focado em desenvolver uma ferramenta que facilite a tradução dos documentos deixados pelo Bruno Borges.
 
-Muito obrigado pelo interesse em contribuir para o projeto!
+## Traduziu alguma página ou encontrou alguma pagina para ser traduzidos?
+Vá para a Wiki deste repositório, lá voce encontrará instruções de como submeter sua tradução para nossa wiki.
 
-Segue abaixo algumas features que precisamos implementar:
+## Segue abaixo algumas features que precisamos implementar:
 
 * Sistema com database para gerenciar imagens e textos
 * Melhoria na qualidade do código do front-end (fizemos na pressa devido a urgência)
 
 ## Contate os fundadores
-
+g
 * Renoir dos Reis (@renoirfaria)
   renofaria@gmail.com
 * Igor Rincon (@igrrincon)
   igrrincon@gmail.com 
+  
+  Muito obrigado pelo interesse em contribuir para o projeto!


### PR DESCRIPTION
Atualização do README.md para direcionar para a Wiki.
Minha proposta é centralizar as traduções na Wiki do GitHub, isso elimina a dependência de um banco de dados e o GitHub se torna o próprio banco de dados.